### PR TITLE
add pre-fill employee info in single edit

### DIFF
--- a/client/src/components/InputModal/index.js
+++ b/client/src/components/InputModal/index.js
@@ -16,7 +16,7 @@ function InputModal(props) {
             return (
               <Form.Group key={input.name}>
                 <Form.Label>{input.label}</Form.Label>
-                <Form.Control type={input.type} placeholder={input.placeholder} name={input.name}
+                <Form.Control type={input.type} placeholder={input.placeholder} name={input.name} value={props.value ? props.value[input.name] : ``}
                   onChange={event => input.onChange(event)}
                 />
                 <Form.Text className="text-muted">{input.text}</Form.Text>

--- a/client/src/pages/Employees/index.js
+++ b/client/src/pages/Employees/index.js
@@ -6,7 +6,6 @@ import DropDownInput from '../../components/DropDownInput/index';
 import DataTable from '../../components/DataTable';
 import API from '../../utils/employeesAPI';
 import InputModal from '../../components/InputModal';
-import { set } from 'mongoose';
 
 function Employees() {
   const [employees, setEmployees] = useState([]);
@@ -124,6 +123,7 @@ function Employees() {
       setModalTitle(`Edit employees`);
     } else {
       console.log(`Only 1 employee selected`)
+      setEmployeeInfo(employees.find(employee => employee._id === selectedEmployees[0]))
       setInputs([...employeeNameInput, ...otherInput]);
       setModalTitle(`Edit an employee`);
     }
@@ -221,6 +221,7 @@ function Employees() {
         submit={submitButtonLabel === `Submit` ? submitButtonPressed : saveButtonPressed}
         submitButtonLabel={submitButtonLabel}
         inputs={inputs} // array of input objs
+        value={employeeInfo ? employeeInfo : undefined}
       />
 
       <Container className='d-flex justify-content-center mt-5'>


### PR DESCRIPTION
In employee page:
add func to bring employee data (a data object from MongoDB) to employeeInfo state when only 1 employee is selected
pass the value to InputModal

In InputModal:
added new props = value.
It'll check if props.value exist? if so, fill the value with respect to input names. If not, do nothing.

`value={props.value ? props.value[input.name] : `