### PR TITLE
Foh page

### DIFF
--- a/client/src/components/MenuItem/index.js
+++ b/client/src/components/MenuItem/index.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Row } from 'react-bootstrap';
+import Button from 'react-bootstrap/Button';
+import './style.css';
+
+function MenuItem(props) {
+  return (
+    <div
+      className='grid-container'
+    >
+      <div
+        className='m-1 text-white'
+        id='menuItem'
+        value={
+          !props.menuItem.value ? props.menuItem.name : props.menuItem.value
+        }
+        style={{
+          width: '8em',
+          height: '8em',
+          backgroundColor: 'transparent',
+          border: 'solid 1px #6c757d',
+          borderRadius: '4px',
+          textAlign: 'center',
+        }}
+      >
+        {props.menuItem.name}
+        <div className='d-flex justify-content-center align-content-flex-end mt-3'>
+          <Row>
+            <Button
+              className='mx-1'
+              size='sm'
+              variant='primary'
+              onClick={props.handleAddToSeatOrder}
+            >
+              Select
+            </Button>
+            <Button
+              className='mx-1'
+              size='sm'
+              variant='success'
+              onClick={props.handleShow}
+            >
+              View
+            </Button>
+          </Row>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MenuItem;

--- a/client/src/components/MenuItem/style.css
+++ b/client/src/components/MenuItem/style.css
@@ -1,0 +1,3 @@
+.grid-container {
+    display: grid;
+  }

--- a/client/src/components/ModalMenuItem/index.js
+++ b/client/src/components/ModalMenuItem/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
+
+function ModalMenuItem(props) {
+  return (
+    <Modal
+      key={props.modalMenuItem._id}
+      show={props.show}
+      onHide={props.handleClose}
+    >
+      <Modal.Header closeButton>
+        <Modal.Title id='contained-modal-title-vcenter'>
+          {props.modalMenuItem.name}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <h4>Description</h4>
+        <p>{props.modalMenuItem.description}</p>
+        <h4>Pairings</h4>
+        <p>{props.modalMenuItem.pairing}</p>
+        <h4>Price</h4>
+        <p>{props.modalMenuItem.price}</p>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant='secondary' onClick={props.handleClose}>
+          Close
+        </Button>
+        <Button
+          variant='primary'
+          onClick={props.handleAddToSeatOrder}
+        >
+          Select
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+export default ModalMenuItem;

--- a/client/src/components/SeatOrder/index.js
+++ b/client/src/components/SeatOrder/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+function SeatOrder(props) {
+  return (
+    <tr className={props.isActiveRow ? 'active' : ''} onClick={props.onClick}>
+      <td>{props.seatOrderNumberIndex + 1}</td>
+      <td>
+        <ul>
+          {props.seatOrder.map((orderItem, index) => (
+            <li key={orderItem._id + '_' + index}>{orderItem.name}</li>
+          ))}
+        </ul>
+      </td>
+    </tr>
+  );
+}
+
+export default SeatOrder;

--- a/client/src/pages/FOH/index.js
+++ b/client/src/pages/FOH/index.js
@@ -1,17 +1,20 @@
 import React, { useEffect, useState } from 'react';
 // import { AddButton, SelectButton } from '../../components/Buttons';
-import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
 
 import { Container, Col, Row } from 'react-bootstrap';
 import API from '../../utils/menuAPI';
+// import API2 from '../../utils/activeOrderAPI';
 
 function FOH() {
   const [menuItems, setMenuItems] = useState([]);
-  const [showModal, setShowModal] = useState(false);
+  const [show, setShow] = useState(null);
+  const [order, setOrder] = useState([]);
+  //   const [newOrder]
 
-  const showDescriptionModal = () => setShowModal(true);
-  const closeDescriptionModal = () => setShowModal(false);
+  const handleClose = () => setShow(false);
+  const handleShow = (id) => setShow(id);
 
   useEffect(() => {
     loadMenu();
@@ -26,49 +29,112 @@ function FOH() {
       .catch((err) => console.error(err));
   };
 
+  function handleAddToOrder(id) {
+    const selectedItem = menuItems.find((item) => item._id === id);
+
+    console.log('id: ' + id);
+    console.log(menuItems);
+
+    const orderItem = {
+      ...selectedItem,
+    };
+
+    setOrder([...order, orderItem]);
+    //   API2.addActiveOrder()
+    // when the menu item is clicked add it to active orders -API post method
+  }
+
+  const modalData = show ? menuItems.find((item) => item._id === show) : null;
+
+  console.log(order);
   return (
-    <div>
-      <Container className='d-flex justify-content-center mt-5'>
-        <Col size='md-8, sm-12'>
-          <Row>
-            {menuItems.map((item) => (
-              <div
-                className='grid-container'
-                key={item._id}
-                style={{
-                  display: 'grid',
-                }}
-              >
+    <>
+      <div>
+        <Container className='d-flex justify-content-center mt-5'>
+          <Col size='md-8, sm-12'>
+            <Row>
+              {menuItems.map((item) => (
                 <div
-                  className='m-1 text-white'
-                  value={!item.value ? item.name : item.value}
+                  className='grid-container'
+                  key={item._id}
                   style={{
-                    width: '8em',
-                    height: '8em',
-                    backgroundColor: 'transparent',
-                    border: 'solid 1px #6c757d',
-                    borderRadius: '4px',
-                    textAlign: 'center',
+                    display: 'grid',
                   }}
                 >
-                  {item.name}
-                  <div className='d-flex justify-content-center align-content-flex-end mt-3'>
-                    <Row>
-                      <Button className='mx-1' size='sm' variant='primary'>
-                        Add
-                      </Button>
-                      <Button className='mx-1' size='sm' variant='success' onClick={showDescriptionModal} >
-                        View
-                      </Button>
-                    </Row>
+                  <div
+                    className='m-1 text-white'
+                    value={!item.value ? item.name : item.value}
+                    style={{
+                      width: '8em',
+                      height: '8em',
+                      backgroundColor: 'transparent',
+                      border: 'solid 1px #6c757d',
+                      borderRadius: '4px',
+                      textAlign: 'center',
+                    }}
+                  >
+                    {item.name}
+                    <div className='d-flex justify-content-center align-content-flex-end mt-3'>
+                      <Row>
+                        <Button
+                          className='mx-1'
+                          size='sm'
+                          variant='primary'
+                          onClick={() => handleAddToOrder(item._id)}
+                        >
+                          Select
+                        </Button>
+                        <Button
+                          className='mx-1'
+                          size='sm'
+                          variant='success'
+                          onClick={handleShow}
+                        >
+                          View
+                        </Button>
+                      </Row>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
-          </Row>
-        </Col>
+              ))}
+            </Row>
+          </Col>
+          {show && (
+            <Modal key={modalData._id} show={show != null} onHide={handleClose}>
+              <Modal.Header closeButton>
+                <Modal.Title id='contained-modal-title-vcenter'>
+                  {modalData.name}
+                </Modal.Title>
+              </Modal.Header>
+              <Modal.Body>
+                <h4>Description</h4>
+                <p>{modalData.description}</p>
+                <h4>Pairings</h4>
+                <p>{modalData.pairing}</p>
+              </Modal.Body>
+              <Modal.Footer>
+                <Button variant='secondary' onClick={handleClose}>
+                  Close
+                </Button>
+                <Button
+                  variant='primary'
+                  onClick={() => handleAddToOrder(modalData._id)}
+                >
+                  Select
+                </Button>
+              </Modal.Footer>
+            </Modal>
+          )}
+        </Container>
+      </div>
+      <Container>
+        <ul className='text-white'>
+          {order.map((orderItem) => (
+            <li key={orderItem._id}>{orderItem.name}</li>
+          ))}
+        </ul>
       </Container>
-    </div>
+    </>
   );
 }
 

--- a/client/src/pages/FOH/index.js
+++ b/client/src/pages/FOH/index.js
@@ -1,11 +1,75 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+// import { AddButton, SelectButton } from '../../components/Buttons';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import Button from 'react-bootstrap/Button';
 
-function FOH(){
-    return(
-        <div>
+import { Container, Col, Row } from 'react-bootstrap';
+import API from '../../utils/menuAPI';
 
-        </div>
-    )
-};
+function FOH() {
+  const [menuItems, setMenuItems] = useState([]);
+  const [showModal, setShowModal] = useState(false);
+
+  const showDescriptionModal = () => setShowModal(true);
+  const closeDescriptionModal = () => setShowModal(false);
+
+  useEffect(() => {
+    loadMenu();
+  }, []);
+
+  const loadMenu = () => {
+    API.getMenu()
+      .then((res) => {
+        console.log(res.data);
+        setMenuItems(res.data);
+      })
+      .catch((err) => console.error(err));
+  };
+
+  return (
+    <div>
+      <Container className='d-flex justify-content-center mt-5'>
+        <Col size='md-8, sm-12'>
+          <Row>
+            {menuItems.map((item) => (
+              <div
+                className='grid-container'
+                key={item._id}
+                style={{
+                  display: 'grid',
+                }}
+              >
+                <div
+                  className='m-1 text-white'
+                  value={!item.value ? item.name : item.value}
+                  style={{
+                    width: '8em',
+                    height: '8em',
+                    backgroundColor: 'transparent',
+                    border: 'solid 1px #6c757d',
+                    borderRadius: '4px',
+                    textAlign: 'center',
+                  }}
+                >
+                  {item.name}
+                  <div className='d-flex justify-content-center align-content-flex-end mt-3'>
+                    <Row>
+                      <Button className='mx-1' size='sm' variant='primary'>
+                        Add
+                      </Button>
+                      <Button className='mx-1' size='sm' variant='success' onClick={showDescriptionModal} >
+                        View
+                      </Button>
+                    </Row>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </Row>
+        </Col>
+      </Container>
+    </div>
+  );
+}
 
 export default FOH;


### PR DESCRIPTION
able to view menu items, select them and start building order by seat number (have to first click on seat number table row and then click select on the menu item that you want to add to the order)
-still need to add option to remove/delete menu item from order when incorrect is clicked or customer changes mind
-will need to incorporate table number somehow for sending activeOrder to BOH (for post method to activeOrder collection) -- perhaps this links to the floorplan page and the server selects the table from there and then starts building the order 
